### PR TITLE
Added Charmed and Downfall assets

### DIFF
--- a/Assets/Scripts/Scriptable Objects/Enemy/Charmed.asset
+++ b/Assets/Scripts/Scriptable Objects/Enemy/Charmed.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14bcd4c7a6ee51543a7cf4900f94b217, type: 3}
+  m_Name: Charmed
+  m_EditorClassIdentifier: 
+  enemyName: 
+  enemyDescription: 
+  enemySprite: {fileID: 0}
+  maxHealth: 0
+  movementPattern: 0
+  clashStrength: 0
+  deathIncome: 0
+  onDeathEffect: 0

--- a/Assets/Scripts/Scriptable Objects/Enemy/Charmed.asset.meta
+++ b/Assets/Scripts/Scriptable Objects/Enemy/Charmed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce5472eb86e1a6d47ba43fe2679b6b10
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scriptable Objects/Enemy/Downfall.asset
+++ b/Assets/Scripts/Scriptable Objects/Enemy/Downfall.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14bcd4c7a6ee51543a7cf4900f94b217, type: 3}
+  m_Name: Downfall
+  m_EditorClassIdentifier: 
+  enemyName: 
+  enemyDescription: 
+  enemySprite: {fileID: 0}
+  maxHealth: 0
+  movementPattern: 0
+  clashStrength: 0
+  deathIncome: 0
+  onDeathEffect: 0

--- a/Assets/Scripts/Scriptable Objects/Enemy/Downfall.asset.meta
+++ b/Assets/Scripts/Scriptable Objects/Enemy/Downfall.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15e37155218e691469ea833bbdae7f96
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added Charmed and Downfall assets to the Enemy scriptable objects folder. Downfalls will likely have to be updated with a unique behaviour, assets currently has them move on Every Two Beats.

Testing/Checking:
1. Open Dissonance project
2. In the Project window's sidebar, click on Scripts
3. In the Project window's sidebar while in Scripts, click on Scriptable Objects
4. In the Project window's sidebar while in Scriptable Objects, click on Enemy
5. In the main area of the Project window, the current Enemy assets should be visible
6. Click on the Charmed enemy asset to inspect it, cross-referencing with the [Enemy Types & Clash System](https://drive.google.com/file/d/1sAqlYQZZDylUF-7XWh4151y9j-jWHnQc/view?usp=drive_link) powerpoint
7. Click on the Downfall enemy asset to inspect it, cross-referencing with the Enemy Types & Clash System powerpoint