### PR TITLE
Updated Charmed and Downfall asset values

### DIFF
--- a/Assets/Scripts/Scriptable Objects/Enemy/Charmed.asset
+++ b/Assets/Scripts/Scriptable Objects/Enemy/Charmed.asset
@@ -12,11 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 14bcd4c7a6ee51543a7cf4900f94b217, type: 3}
   m_Name: Charmed
   m_EditorClassIdentifier: 
-  enemyName: 
+  enemyName: Charmed
   enemyDescription: 
   enemySprite: {fileID: 0}
-  maxHealth: 0
-  movementPattern: 0
+  maxHealth: 55
+  movementPattern: 4
   clashStrength: 0
-  deathIncome: 0
+  deathIncome: 40
   onDeathEffect: 0

--- a/Assets/Scripts/Scriptable Objects/Enemy/Downfall.asset
+++ b/Assets/Scripts/Scriptable Objects/Enemy/Downfall.asset
@@ -12,11 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 14bcd4c7a6ee51543a7cf4900f94b217, type: 3}
   m_Name: Downfall
   m_EditorClassIdentifier: 
-  enemyName: 
+  enemyName: Downfall
   enemyDescription: 
   enemySprite: {fileID: 0}
-  maxHealth: 0
-  movementPattern: 0
+  maxHealth: 15
+  movementPattern: 5
   clashStrength: 0
   deathIncome: 0
   onDeathEffect: 0


### PR DESCRIPTION
Thought this was part of the initial push, and it wasn't, apparently. Apologies.

Updates the Charmed and Downfall assets in the Scripts -> Scriptable Objects -> Enemy folder to have an initial set of values.